### PR TITLE
Get omitted zero value on ENUM field.

### DIFF
--- a/library/DrSlump/Protobuf/Message.php
+++ b/library/DrSlump/Protobuf/Message.php
@@ -172,18 +172,24 @@ abstract class Message implements \ArrayAccess
 
         if (!$f->isExtension()) {
 
-            return $idx !== NULL
+            $value = $idx !== NULL
                    ? $this->{$name}[$idx]
                    : $this->$name;
 
         } else {
 
-            return $idx !== NULL
+            $value = $idx !== NULL
                    ? $this->_extensions[$name][$idx]
                    : $this->_extensions[$name];
 
         }
 
+        //Enum default value is zero on version 3
+        if ($value === NULL && $f->getType() === Protobuf::TYPE_ENUM) {
+            $value = 0;
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
Hi 

Enum field in proto3 has default value 0.
And proto3 serializer omit default value at enum.

detail: https://developers.google.com/protocol-buffers/docs/proto3#enum

I want to get omitted zero value from a proto3 event.
