### PR TITLE
Update package name and homepage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "datto/protobuf-php",
+    "name": "stanley-cheung/protobuf-php",
     "description": "PHP implementation of Google's Protocol Buffers",
     "keywords": ["protobuf", "protocol buffer", "serializing"],
-    "homepage": "https://github.com/datto/Protobuf-PHP",
+    "homepage": "https://github.com/stanley-cheung/Protobuf-PHP",
     "type": "library",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Hi Stanley!

In order for packages downstream from [grpc/grpc](https://github.com/grpc/grpc) to work property, we need to republish the Protobuf-PHP package. Currently, grpc requires `datto/Protobuf-PHP`, which is published on packagist and links to [this repository](https://github.com/datto/Protobuf-PHP).

grpc uses the `repositories` key to override this and install [your fork](https://github.com/stanley-cheung/Protobuf-PHP), however the `repositories` key in composer.json is [root only](https://getcomposer.org/doc/04-schema.md#root-package), which means that any packages requiring grpc will ignore the repository specified in grpc and install the package from packagist.

In other words, if you run `composer install` in the grpc root folder, you'll get the stanley-cheung version. If you run `composer install` from a package requiring grpc, you'll get the datto version.

This PR will fix this problem by allowing us to republish Protobuf-PHP on packagist under a different vendor (as `stanley-cheung/protobuf-php`). The second step will be to update grpc to require this package instead of `datto/protobuf-php`.

Let me know if there are any issues!
