### PR TITLE
Rename conflicting function signature in PHP7

### DIFF
--- a/library/DrSlump/Protobuf/Message.php
+++ b/library/DrSlump/Protobuf/Message.php
@@ -64,7 +64,7 @@ abstract class Message implements \ArrayAccess
         if (is_numeric($offset)) {
             return $this->_has($offset);
         } else {
-            return $this->hasExtension($offset);
+            return $this->_hasExtension($offset);
         }
     }
 
@@ -73,7 +73,7 @@ abstract class Message implements \ArrayAccess
         if (is_numeric($offset)) {
             $this->_set($offset, $value);
         } else {
-            $this->setExtension($offset, $value);
+            $this->_setExtension($offset, $value);
         }
     }
 
@@ -82,7 +82,7 @@ abstract class Message implements \ArrayAccess
         if (is_numeric($offset)) {
             return $this->_get($offset);
         } else {
-            return $this->getExtension($offset);
+            return $this->_getExtension($offset);
         }
     }
 
@@ -91,7 +91,7 @@ abstract class Message implements \ArrayAccess
         if (is_numeric($offset)) {
             $this->_clear($offset);
         } else {
-            $this->clearExtension($offset);
+            $this->_clearExtension($offset);
         }
     }
 
@@ -287,7 +287,7 @@ abstract class Message implements \ArrayAccess
      * @param string $extname
      * @return bool
      */
-    public function hasExtension($extname)
+    public function _hasExtension($extname)
     {
         return isset($this->_extensions[$extname]);
     }
@@ -299,7 +299,7 @@ abstract class Message implements \ArrayAccess
      * @param int|null $idx
      * @return mixed
      */
-    public function getExtension($extname, $idx = null)
+    public function _getExtension($extname, $idx = null)
     {
         if (!isset($this->_extensions[$extname])) return NULL;
 
@@ -314,7 +314,7 @@ abstract class Message implements \ArrayAccess
      * @param string $extname
      * @return array
      */
-    public function getExtensionList($extname)
+    public function _getExtensionList($extname)
     {
         return isset($this->_extensions[$extname])
                ? $this->_extensions[$extname]
@@ -329,7 +329,7 @@ abstract class Message implements \ArrayAccess
      * @param int|null $idx
      * @return \DrSlump\Protobuf\Message - Fluent Interface
      */
-    public function setExtension($extname, $value, $idx = null)
+    public function _setExtension($extname, $value, $idx = null)
     {
         if (NULL !== $idx) {
             if (empty($this->_extensions)) {
@@ -350,7 +350,7 @@ abstract class Message implements \ArrayAccess
      * @param mixed $value
      * @return \DrSlump\Protobuf\Message - Fluent Interface
      */
-    public function addExtension($extname, $value)
+    public function _addExtension($extname, $value)
     {
         $this->_extensions[$extname][] = $value;
     }
@@ -359,7 +359,7 @@ abstract class Message implements \ArrayAccess
      * @param  $extname
      * @return void
      */
-    public function clearExtension($extname)
+    public function _clearExtension($extname)
     {
         unset($this->_extensions[$extname]);
     }


### PR DESCRIPTION
When trying to generate client code for the gRPC PHP library on PHP7, I got these errors:

```
--php_out: protoc-gen-php: Plugin output is unparseable: \nWarning: Declaration of
google\\protobuf\\FileDescriptorProto::hasExtension() should be compatible with 
DrSlump\\Protobuf\\Message::hasExtension($extname) in 
/usr/local/lib/php/DrSlump/Protobuf/Compiler/protos/descriptor.pb.php on line 98\n\nWarning: 
Declaration of google\\protobuf\\FileDescriptorProto::getExtension($idx = NULL) should be 
compatible with DrSlump\\Protobuf\\Message::getExtension($extname, $idx = NULL) in 
/usr/local/lib/php/DrSlump/Protobuf/Compiler/protos/descriptor.pb.php on line 98\n\nWarning: 
Declaration of google\\protobuf\\FileDescriptorProto::getExtensionList() should be compatible with 
DrSlump\\Protobuf\\Message::getExtensionList($extname) in 
/usr/local/lib/php/DrSlump/Protobuf/Compiler/protos/descriptor.pb.php on line 98
```

Apparently, if a .proto has a field named `extension`, the generated class will have functions like `getExtension`, `hasExtension` which will conflict with the parent class with the same function names but different signatures. Apparently these have been `E_STRICT` warnings in PHP5 but became plain warnings in [PHP7](http://stackoverflow.com/questions/36079651/silence-declaration-should-be-compatible-warnings-in-php-7). These warnings are being outputted by the `protoc-gen-php` plugin for which the main `protoc` generator cannot parse. 

I have renamed the functions in the parent `DrSlump\Protobuf\Message` class to be `_getExtension`, `_hasExtension` to avoid the conflict.
