### PR TITLE
fix package name is empty

### DIFF
--- a/library/DrSlump/Protobuf/Compiler/PhpGenerator.php
+++ b/library/DrSlump/Protobuf/Compiler/PhpGenerator.php
@@ -448,7 +448,7 @@ class PhpGenerator extends AbstractGenerator
         $s[]= '     */';
         $server_stream = $method->getServerStreaming();
         $client_stream = $method->getClientStreaming();
-        $service_fqn = $ns . '.' . $service->getName();
+        $service_fqn = ($ns ? $ns . '.' : '') . $service->getName();
         if($client_stream){
           if($server_stream){
             $s[]= '    public function ' . $method->getName() . '($metadata = array(), $options = array()) {';


### PR DESCRIPTION
generate code like blow when package name is empty: 
$this->_simpleRequest('/.Test/Method',...
